### PR TITLE
winebus.sys: Map more SDL Xbox controllers

### DIFF
--- a/dlls/winebus.sys/bus_sdl.c
+++ b/dlls/winebus.sys/bus_sdl.c
@@ -69,9 +69,11 @@ static const WORD PID_XBOX_CONTROLLERS[] =  {
     0x028f, /* Xbox360 Wireless Controller */
     0x02d1, /* Xbox One Controller */
     0x02dd, /* Xbox One Controller (Covert Forces/Firmware 2015) */
+    0x02e0, /* Xbox One X Controller */
     0x02e3, /* Xbox One Elite Controller */
     0x02e6, /* Wireless XBox Controller Dongle */
     0x02ea, /* Xbox One S Controller */
+    0x02fd, /* Xbox One S Controller (Firmware 2017) */
     0x0719, /* Xbox 360 Wireless Adapter */
 };
 


### PR DESCRIPTION
These device ids are usually returned by newer firmware versions.
Especially, the Android mode of the controller (when paired by bluetooth
to a Linux system) changes the input mapping of the controller. The
current kernel drivers do not correct this, xpadneo[1] is needed as the
driver to get correct mapping.

[1]: https://github.com/atar-axis/xpadneo

Signed-off-by: Kai Krakow <kai@kaishome.de>